### PR TITLE
Prefix public/ image URLs with the app's path prefix

### DIFF
--- a/client/lib/asset_url.js
+++ b/client/lib/asset_url.js
@@ -1,0 +1,9 @@
+// Files under public/ are served relative to the app's path prefix: with
+// ROOT_URL https://magic.earthref.org/MagIC, Meteor strips a leading /MagIC from
+// every request before looking in public/, so a hardcoded src="/MagIC/people/x.jpg"
+// resolves to public/people/x.jpg and 404s. Prepend the runtime prefix (empty when
+// the app is served from the host root, e.g. local `meteor` on :3000).
+export default function assetUrl(path) {
+  const prefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+  return `${prefix}${path}`;
+}

--- a/client/modules/common/components/layout.jsx
+++ b/client/modules/common/components/layout.jsx
@@ -12,6 +12,7 @@ import {portals} from '/lib/configs/portals';
 import Navigation from '/client/modules/common/components/navigation';
 import { User } from './user';
 import { LogIn } from './login';
+import assetUrl from '/client/lib/asset_url';
 
 class Layout extends React.Component {
 
@@ -139,7 +140,7 @@ class Layout extends React.Component {
               <a className={'ui button compact basic ' + portals['EarthRef.org'].color} style={{margin: '0.5em 1em'}}
                  href="https://github.com/earthref/FIESTA-API#readme">
                  Powered by
-                 <img src="/MagIC/FIESTA.png" style={{ height: '1.75em', margin: '-1.25em 0.5em -.5em' }}/>
+                 <img src={assetUrl('/MagIC/FIESTA.png')} style={{ height: '1.75em', margin: '-1.25em 0.5em -.5em' }}/>
                 <b>FIESTA</b>
               </a>
             </div>

--- a/client/modules/common/components/login.jsx
+++ b/client/modules/common/components/login.jsx
@@ -5,6 +5,7 @@ import { useLocation, useHistory } from "react-router-dom";
 import Cookies from 'js-cookie';
 
 import {portals} from '/lib/configs/portals';
+import assetUrl from '/client/lib/asset_url';
 
 const orcidURL = Meteor.isDevelopment ? 'sandbox.orcid.org' : 'orcid.org';
 const orcidClientID = Meteor.isDevelopment ? 'APP-F8JQS3NCYGINEF7B' : 'APP-7V8YQW9CI7R01H1T';
@@ -43,7 +44,7 @@ export function LogIn({ openInitially, className, portal }) {
 							<Header as='h4' textAlign='center'>
 								With an ORCID iD:
 							</Header>
-							<img src='/ORCIDiD_icon64x64.png' style={{ margin: '1em auto', display: 'block' }}/>
+							<img src={assetUrl('/ORCIDiD_icon64x64.png')} style={{ margin: '1em auto', display: 'block' }}/>
 							<Button 
 								fluid 
 								color='black' 
@@ -209,7 +210,7 @@ export function ORCIDLoggingInModal({ code }) {
 				{ error &&
 					<Button as='a' href={ orcidAuthorizeURL }>
 						<img 
-							src='/ORCIDiD_icon64x64.png'
+							src={assetUrl('/ORCIDiD_icon64x64.png')}
 							style={{ margin: '-.2em 1em -.3em -.5em', height: '1.25em' }}
 						/>
 						Retry ORCID Login

--- a/client/modules/common/components/user.jsx
+++ b/client/modules/common/components/user.jsx
@@ -8,6 +8,7 @@ import uuid from 'uuid';
 import * as EmailValidator from 'email-validator';
 
 import { portals } from '/lib/configs/portals';
+import assetUrl from '/client/lib/asset_url';
 
 const orcidURL = Meteor.isDevelopment ? 'sandbox.orcid.org' : 'orcid.org';
 const orcidClientID = Meteor.isDevelopment ? 'APP-F8JQS3NCYGINEF7B' : 'APP-7V8YQW9CI7R01H1T';
@@ -108,7 +109,7 @@ export function User({ openInitially, className, portal }) {
 									</Table.Row>
 									<Table.Row>
 										<Table.Cell>
-											<img src='/ORCIDiD_icon64x64.png'
+											<img src={assetUrl('/ORCIDiD_icon64x64.png')}
 												style={{ height: '1.25em', margin: '-.25em .25em -.25em 0' }}
 											/>
 											ORCID iD
@@ -208,7 +209,7 @@ export function User({ openInitially, className, portal }) {
 													}
 												}}
 											>
-												<img src='/ORCIDiD_icon64x64.png'
+												<img src={assetUrl('/ORCIDiD_icon64x64.png')}
 													style={{ height: '1.25em', margin: '-.25em .25em -.25em 0' }}
 												/>
 												Disconnect Your EarthRef Account From ORCID
@@ -224,7 +225,7 @@ export function User({ openInitially, className, portal }) {
 									localStorage.setItem('orcid.nextLocation', location.pathname + location.search);
 									window.location.href = orcidAuthorizeURL;
 								}}>
-									<img src='/ORCIDiD_icon64x64.png'
+									<img src={assetUrl('/ORCIDiD_icon64x64.png')}
 										style={{ height: '1.25em', margin: '-.25em .25em -.25em 0' }}
 									/>
 									Connect Your EarthRef Account to ORCID

--- a/client/modules/common/components/user_item.jsx
+++ b/client/modules/common/components/user_item.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import {Item, Label} from 'semantic-ui-react';
 
 import { portals } from '/lib/configs/portals.js';
+import assetUrl from '/client/lib/asset_url';
 
 class UserItem extends React.Component {
 
@@ -52,7 +53,7 @@ class UserItem extends React.Component {
             }
             { users[id].orcid &&
               <Label as='a' image href={'https://orcid.org/' + users[id].orcid}>
-                <img src='/ORCIDiD_icon64x64.png'/>
+                <img src={assetUrl('/ORCIDiD_icon64x64.png')}/>
                 {'https://orcid.org/' + users[id].orcid}
               </Label>
             }

--- a/client/modules/magic/components/home.jsx
+++ b/client/modules/magic/components/home.jsx
@@ -7,6 +7,7 @@ import SearchDividedList from "/client/modules/common/containers/search_divided_
 import SearchSummariesListItem from "/client/modules/magic/containers/search_summaries_list_item";
 import News from "/client/modules/magic/components/home_news";
 import { levels } from "/lib/configs/magic/search_levels.js";
+import assetUrl from '/client/lib/asset_url';
 
 export default class extends React.Component {
   constructor(props) {
@@ -289,7 +290,7 @@ export default class extends React.Component {
                   <div className="ui tiny image">
                     <img
                       className="ui bordered image"
-                      src="/MagIC/plot.png"
+                      src={assetUrl('/MagIC/plot.png')}
                       style={{ border: "1px solid rgba(0, 0, 0, 0.1)" }}
                     />
                   </div>
@@ -307,7 +308,7 @@ export default class extends React.Component {
                   <div className="ui tiny image">
                     <img
                       className="ui bordered image"
-                      src="/MagIC/plot.png"
+                      src={assetUrl('/MagIC/plot.png')}
                       style={{ border: "1px solid rgba(0, 0, 0, 0.1)" }}
                     />
                   </div>
@@ -325,7 +326,7 @@ export default class extends React.Component {
                   <div className="ui tiny image">
                     <img
                       className="ui bordered image"
-                      src="/MagIC/plot.png"
+                      src={assetUrl('/MagIC/plot.png')}
                       style={{ border: "1px solid rgba(0, 0, 0, 0.1)" }}
                     />
                   </div>
@@ -343,7 +344,7 @@ export default class extends React.Component {
                   <div className="ui tiny image">
                     <img
                       className="ui bordered image"
-                      src="/MagIC/plot.png"
+                      src={assetUrl('/MagIC/plot.png')}
                       style={{ border: "1px solid rgba(0, 0, 0, 0.1)" }}
                     />
                   </div>
@@ -361,7 +362,7 @@ export default class extends React.Component {
                   <div className="ui tiny image">
                     <img
                       className="ui bordered image"
-                      src="/MagIC/plot.png"
+                      src={assetUrl('/MagIC/plot.png')}
                       style={{ border: "1px solid rgba(0, 0, 0, 0.1)" }}
                     />
                   </div>
@@ -379,7 +380,7 @@ export default class extends React.Component {
                   <div className="ui tiny image">
                     <img
                       className="ui bordered image"
-                      src="/MagIC/plot.png"
+                      src={assetUrl('/MagIC/plot.png')}
                       style={{ border: "1px solid rgba(0, 0, 0, 0.1)" }}
                     />
                   </div>

--- a/client/modules/magic/components/home_news.jsx
+++ b/client/modules/magic/components/home_news.jsx
@@ -3,6 +3,7 @@ import {Link} from 'react-router-dom';
 import {Image, Message} from 'semantic-ui-react';
 
 import {portals} from '/lib/configs/portals.js';
+import assetUrl from '/client/lib/asset_url';
 
 export default class extends React.Component {
 
@@ -11,7 +12,7 @@ export default class extends React.Component {
       <div style={{textAlign: "justify"}}>
         <div className="ui divider"></div>
         <h3>
-          <Image size="mini" src="/MagIC/pmag_org_logo.png" floated="left"/>
+          <Image size="mini" src={assetUrl('/MagIC/pmag_org_logo.png')} floated="left"/>
           {`Paleomagnetism.org file converter`}
         </h3>
         <p>
@@ -20,7 +21,7 @@ export default class extends React.Component {
           {`. Visit the beta site and try it out. Please send comments, problem reports, or requests for additional formats to paleomagnetism.org@gmail.com`}
         </p>
         <h3>
-          <Image size="mini" src="/MagIC/agu.jpg" floated="left"/>
+          <Image size="mini" src={assetUrl('/MagIC/agu.jpg')} floated="left"/>
           {`MagIC at AGU`}
         </h3>
         <p>
@@ -58,7 +59,7 @@ export default class extends React.Component {
         </p>
         <div className="ui divider"></div>
         <h3>
-          <Image size="mini" src="/MagIC/sio.jpg" floated="left"/>
+          <Image size="mini" src={assetUrl('/MagIC/sio.jpg')} floated="left"/>
           {` 2021 MagIC Workshop`}
         </h3>
         <p>
@@ -76,7 +77,7 @@ export default class extends React.Component {
         </p>
         <div className="ui divider"></div>
         <h3>
-          <Image size="mini" src="/MagIC/youtube.png" floated="left"/>
+          <Image size="mini" src={assetUrl('/MagIC/youtube.png')} floated="left"/>
           <a href="https://www.youtube.com/playlist?list=PLirL2unikKCgUkHQ3m8nT29tMCJNBj4kj"><font color="000000">2020 MagIC Workshop Tutorial Videos</font></a>
         </h3>
         <p>
@@ -95,7 +96,7 @@ export default class extends React.Component {
         {`.`}
         </p>
         <h3>
-          <Image size="mini" src="/MagIC/ec.jpg" floated="left"/>
+          <Image size="mini" src={assetUrl('/MagIC/ec.jpg')} floated="left"/>
           {` Project 419 / GeoCODES`}
         </h3>
         <p>

--- a/client/modules/magic/components/menu/about.jsx
+++ b/client/modules/magic/components/menu/about.jsx
@@ -3,6 +3,7 @@ import {Link} from 'react-router-dom';
 import {Grid, Image, Container, Segment, Header, Divider} from 'semantic-ui-react';
 
 import IconButton from '/client/modules/common/components/icon_button';
+import assetUrl from '/client/lib/asset_url';
 
 export default class extends React.Component {
 
@@ -26,22 +27,22 @@ export default class extends React.Component {
                             </Grid.Column>
                             <Grid.Column>
                                 <Segment>
-                                    <Image src='/MagIC/orgs/nsf_small.png'/>
+                                    <Image src={assetUrl('/MagIC/orgs/nsf_small.png')}/>
                                 </Segment>
                             </Grid.Column>
                             <Grid.Column>
                                 <Segment>
-                                    <Image src='/MagIC/orgs/osu_small.png'/>
+                                    <Image src={assetUrl('/MagIC/orgs/osu_small.png')}/>
                                 </Segment>
                             </Grid.Column>
                             <Grid.Column>
                                 <Segment>
-                                    <Image src='/MagIC/orgs/ucsd_small.png'/>
+                                    <Image src={assetUrl('/MagIC/orgs/ucsd_small.png')}/>
                                 </Segment>
                             </Grid.Column>
                             <Grid.Column>
                                 <Segment>
-                                    <Image src='/MagIC/orgs/uminn_small.png'/>
+                                    <Image src={assetUrl('/MagIC/orgs/uminn_small.png')}/>
                                 </Segment>
                             </Grid.Column>
                             <Grid.Column>
@@ -58,7 +59,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#akoppers">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="Marine Geology and Geophysics, CEOAS, OSU" >
-                                    <img src="/MagIC/people/akoppers.jpg" />
+                                    <img src={assetUrl('/MagIC/people/akoppers.jpg')} />
                                 </div><br/>
                                 Anthony Koppers
                                 <div className="sub header">Professor at<br/>CEOAS, OSU</div>
@@ -67,7 +68,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#nswanson-hysell">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="Department of Earth and Environmental Sciences, University of Minnesota" >
-                                    <img src="/MagIC/people/nswanson-hysell.jpg" />
+                                    <img src={assetUrl('/MagIC/people/nswanson-hysell.jpg')} />
                                 </div><br/>
                                 Nick Swanson-Hysell
                                 <div className="sub header">Associate Professor at<br/>University of Minnesota</div>
@@ -76,7 +77,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#mbrown">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="IRM, University of Minnesota" >
-                                    <img src="/MagIC/people/mbrown.jpg" />
+                                    <img src={assetUrl('/MagIC/people/mbrown.jpg')} />
                                 </div><br/>
                                 Max Brown
                                 <div class="sub header">Research Associate Professor <br/>at IRM, U. of Minnesota</div>
@@ -85,7 +86,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#jfeinberg">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="College of Science and Engineering, Earth & Environmental Sciences, IRM, University of Minnesota" >
-                                    <img src="/MagIC/people/jfeinberg.jpg" />
+                                    <img src={assetUrl('/MagIC/people/jfeinberg.jpg')} />
                                 </div><br/>
                                 Josh Feinberg
                                 <div class="sub header">Professor at <br/>IRM, U. of Minnesota</div>
@@ -94,7 +95,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#cconstable">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="Institute for Geophysics and Planetary Physics, SIO, UCSD" >
-                                    <img src="/MagIC/people/cconstable.jpg" />
+                                    <img src={assetUrl('/MagIC/people/cconstable.jpg')} />
                                 </div><br/>
                                 Cathy Constable
                                 <div className="sub header">Professor at<br/>SIO, UCSD</div>
@@ -105,7 +106,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#ltauxe">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="Geosciences Research Division, SIO, UCSD" >
-                                    <img src="/MagIC/people/ltauxe.jpg" />
+                                    <img src={assetUrl('/MagIC/people/ltauxe.jpg')} />
                                 </div><br/>
                                 Lisa Tauxe
                                 <div className="sub header">Professor Emerita<br/>at SIO, UCSD</div>
@@ -114,7 +115,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#njarboe">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="Marine Geology and Geophysics, CEOAS, OSU" >
-                                    <img src="/MagIC/people/njarboe.jpg" />
+                                    <img src={assetUrl('/MagIC/people/njarboe.jpg')} />
                                 </div><br/>
                                 Nick Jarboe
                                 <div className="sub header">Data Analyst via<br/>CEOAS, OSU</div>
@@ -123,7 +124,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#rminnet">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="Marine Geology and Geophysics, CEOAS, OSU" >
-                                    <img src="/MagIC/people/rminnett.jpg" />
+                                    <img src={assetUrl('/MagIC/people/rminnett.jpg')} />
                                 </div><br/>
                                 Rupert Minnett
                                 <div className="sub header">Programmer via<br/>CEOAS, OSU</div>
@@ -132,7 +133,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <a className="ui center aligned small icon header" target="_top" href="/MagIC/contact/#psolheid">
                                 <div className="ui huge icon bordered rounded image" data-tooltip="IRM, University of Minnesota" >
-                                    <img src="/MagIC/people/psolheid.jpg" />
+                                    <img src={assetUrl('/MagIC/people/psolheid.jpg')} />
                                 </div><br/>
                                 Peat Solheid
                                 <div class="sub header">Senior Scientist at <br/>IRM, U. of Minnesota</div>
@@ -150,7 +151,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="Associate Professor, University of Oslo" >
-                                        <img src="/MagIC/people/mdomeier.jpg" />
+                                        <img src={assetUrl('/MagIC/people/mdomeier.jpg')} />
                                     </div><br/>
                                     Mathew Domeier
                                     <div className="sub header">
@@ -162,7 +163,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="Assistant Professor, Harvard University" >
-                                        <img src="/MagIC/people/rfu.jpg" />
+                                        <img src={assetUrl('/MagIC/people/rfu.jpg')} />
                                     </div><br/>
                                     Roger Fu
                                     <div className="sub header">
@@ -175,7 +176,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="Professor, Ludwig Maximilians Universität" >
-                                        <img src="/MagIC/people/sgilder.jpg" />
+                                        <img src={assetUrl('/MagIC/people/sgilder.jpg')} />
                                     </div><br/>
                                     Stuart Gilder
                                     <div className="sub header">
@@ -188,7 +189,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="CNRS Researcher, IPGP" >
-                                        <img src="/MagIC/people/flagroix.jpg" />
+                                        <img src={assetUrl('/MagIC/people/flagroix.jpg')} />
                                     </div><br/>
                                     France Lagroix
                                     <div className="sub header">
@@ -200,7 +201,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="Associate Professor, University of Utah" >
-                                        <img src="/MagIC/people/plippert.jpg" />
+                                        <img src={assetUrl('/MagIC/people/plippert.jpg')} />
                                     </div><br/>
                                     Peter Lippert
                                     <div className="sub header">
@@ -215,7 +216,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="Assistant Professor, University of Florida" >
-                                        <img src="/MagIC/people/csprain.jpg" />
+                                        <img src={assetUrl('/MagIC/people/csprain.jpg')} />
                                     </div><br/>
                                     Courtney Sprain
                                     <div className="sub header">
@@ -227,7 +228,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui medium icon bordered rounded image" data-tooltip="Assistant Professor, Dartmouth College" >
-                                        <img src="/MagIC/people/sslotznick.jpg" />
+                                        <img src={assetUrl('/MagIC/people/sslotznick.jpg')} />
                                     </div><br/>
                                     Sarah Slotznick
                                     <div className="sub header">
@@ -240,7 +241,7 @@ export default class extends React.Component {
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="Assistant Professor, Stanford University
 " >
-                                        <img src="/MagIC/people/stikoo.jpg" />
+                                        <img src={assetUrl('/MagIC/people/stikoo.jpg')} />
                                     </div><br/>
                                     Sonia Tikoo
                                     <div className="sub header">
@@ -252,7 +253,7 @@ export default class extends React.Component {
                             <Grid.Column>
                                 <div className="ui center aligned small icon header">
                                     <div className="ui big icon bordered rounded image" data-tooltip="Professor, Utrecht University" >
-                                        <img src="/MagIC/people/dvanhinsbergen.jpg" />
+                                        <img src={assetUrl('/MagIC/people/dvanhinsbergen.jpg')} />
                                     </div><br/>
                                     Douwe van Hinsbergen
                                     <div className="sub header">

--- a/client/modules/magic/components/menu/grand_challenges.jsx
+++ b/client/modules/magic/components/menu/grand_challenges.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Grid} from 'semantic-ui-react';
+import assetUrl from '/client/lib/asset_url';
 
 export default class extends React.Component {
 
@@ -10,7 +11,7 @@ export default class extends React.Component {
 					<Grid.Row>
 						<Grid.Column width={3}>
 						<div className="ui small bordered rounded image" style={{fontSize: '3em'}}>
-                <img src="/MagIC/glatzmaierReversal.jpg"/>
+                <img src={assetUrl('/MagIC/glatzmaierReversal.jpg')}/>
 						</div>
 						</Grid.Column>
 						<Grid.Column width={13} textAlign='justified'>
@@ -20,7 +21,7 @@ export default class extends React.Component {
 					<Grid.Row>
 						<Grid.Column width={3}>
 						<div className="ui small bordered rounded image" style={{fontSize: '3em'}}>
-							<img src="/MagIC/polarWanderPlumes.jpg"/>
+							<img src={assetUrl('/MagIC/polarWanderPlumes.jpg')}/>
 						</div>
 						</Grid.Column>
 						<Grid.Column width={13} textAlign='justified'>
@@ -30,7 +31,7 @@ export default class extends React.Component {
 					<Grid.Row>
 						<Grid.Column width={3}>
 						<div className="ui small bordered rounded image" style={{fontSize: '3em'}}>
-							<img src="/MagIC/widemereLakeCore.png"/>
+							<img src={assetUrl('/MagIC/widemereLakeCore.png')}/>
 						</div>
 						</Grid.Column>
 						<Grid.Column width={13} textAlign='justified'>
@@ -40,7 +41,7 @@ export default class extends React.Component {
 					<Grid.Row>
 						<Grid.Column width={3}>
 						<div className="ui small bordered rounded image" style={{fontSize: '3em'}}>
-							<img src="/MagIC/pigeon.jpg"/>
+							<img src={assetUrl('/MagIC/pigeon.jpg')}/>
 						</div>
 						</Grid.Column>
 						<Grid.Column width={13} textAlign='justified'>
@@ -54,7 +55,7 @@ export default class extends React.Component {
 					<Grid.Row>
 						<Grid.Column width={3}>
 						<div className="ui small bordered rounded image" style={{fontSize: '3em'}}>
-							<img src="/MagIC/loessVicksburg.jpg"/>
+							<img src={assetUrl('/MagIC/loessVicksburg.jpg')}/>
 						</div>
 						</Grid.Column>
 						<Grid.Column width={13} textAlign='justified'>
@@ -64,7 +65,7 @@ export default class extends React.Component {
 					<Grid.Row>
 						<Grid.Column width={3}>
 						<div className="ui small bordered rounded image" style={{fontSize: '3em'}}>
-							<img src="/MagIC/seymchanMeteorite.jpg"/>
+							<img src={assetUrl('/MagIC/seymchanMeteorite.jpg')}/>
 						</div>
 						</Grid.Column>
 						<Grid.Column width={13} textAlign='justified'>

--- a/client/modules/magic/components/menu/technology.jsx
+++ b/client/modules/magic/components/menu/technology.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Grid, Image, Label, Segment, Container, Header, Divider } from 'semantic-ui-react';
+import assetUrl from '/client/lib/asset_url';
 
 const labelStyle = { textAlign:'center', textOverflow:'ellipsis', overflow:'hidden' };
 
@@ -15,7 +16,7 @@ export default class extends React.Component {
 					This data model, along with method codes and vocabulary lists, can be browsed via the MagIC website, downloaded as JSON files for reuse, and easily updated by the MagIC team by request from the community via either email or reporting an issue at the MagIC GitHub repository.
 				</Container>
 				<Divider hidden/>
-				<Image style={{ maxWidth:800, margin:'auto' }} src="/MagIC/technology/ecosystem.png" fluid/>
+				<Image style={{ maxWidth:800, margin:'auto' }} src={assetUrl('/MagIC/technology/ecosystem.png')} fluid/>
 				<Divider hidden/>
 				<Container fluid textAlign='justified'>
 					<Header size='medium' dividing>Technologies and Surrounding Ecosystem</Header>
@@ -29,49 +30,49 @@ export default class extends React.Component {
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>React</Label>
-									<Image src='/MagIC/technology/react.svg'/>
+									<Image src={assetUrl('/MagIC/technology/react.svg')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Semantic UI</Label>
-									<Image src='/MagIC/technology/semantic-ui.svg'/>
+									<Image src={assetUrl('/MagIC/technology/semantic-ui.svg')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Meteor</Label>
-									<Image src='/MagIC/technology/meteor.svg'/>
+									<Image src={assetUrl('/MagIC/technology/meteor.svg')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>MongoDB</Label>
-									<Image src='/MagIC/technology/mongodb.svg'/>
+									<Image src={assetUrl('/MagIC/technology/mongodb.svg')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Elasticsearch</Label>
-									<Image src='/MagIC/technology/elasticsearch.svg'/>
+									<Image src={assetUrl('/MagIC/technology/elasticsearch.svg')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>AWS</Label>
-									<Image src='/MagIC/technology/aws.svg'/>
+									<Image src={assetUrl('/MagIC/technology/aws.svg')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 										<Label attached='bottom' style={labelStyle}>Docker</Label>
-										<Image src='/MagIC/technology/docker.svg'/>
+										<Image src={assetUrl('/MagIC/technology/docker.svg')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Kubernetes</Label>
-									<Image src='/MagIC/technology/kubernetes.svg'/>
+									<Image src={assetUrl('/MagIC/technology/kubernetes.svg')}/>
 								</Segment>
 							</Grid.Column>
 						</Grid.Row>
@@ -87,37 +88,37 @@ export default class extends React.Component {
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Reference Metadata</Label>
-									<Image src='/MagIC/technology/crossref.png'/>
+									<Image src={assetUrl('/MagIC/technology/crossref.png')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>DOI Minting</Label>
-									<Image src='/MagIC/technology/EZID.png'/>
+									<Image src={assetUrl('/MagIC/technology/EZID.png')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Structured Data</Label>
-									<Image src='/MagIC/technology/json-ld.png'/>
+									<Image src={assetUrl('/MagIC/technology/json-ld.png')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Nature Repository</Label>
-									<Image src='/MagIC/technology/scientific data.png'/>
+									<Image src={assetUrl('/MagIC/technology/scientific data.png')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>Data DOI Metadata</Label>
-									<Image src='/MagIC/technology/datacite.png'/>
+									<Image src={assetUrl('/MagIC/technology/datacite.png')}/>
 								</Segment>
 							</Grid.Column>
 							<Grid.Column>
 								<Segment>
 									<Label attached='bottom' style={labelStyle}>ORCiD Member</Label>
-									<Image src='/MagIC/technology/orcid.png'/>
+									<Image src={assetUrl('/MagIC/technology/orcid.png')}/>
 								</Segment>
 							</Grid.Column>
 						</Grid.Row>


### PR DESCRIPTION
## Problem

On MARFIK (`magic.earthref.org/MagIC`) the news icons, About page people and org logos, technology page logos, the FIESTA header logo and the ORCID icon are all broken.

ROOT_URL there ends in `/MagIC`, so Meteor sets `ROOT_URL_PATH_PREFIX=/MagIC` and strips it from every request before looking in `public/`. A hardcoded `src="/MagIC/people/x.jpg"` becomes `/people/x.jpg`, which does not exist (the file is `public/MagIC/people/x.jpg`), so the request falls through to the SPA HTML. The unprefixed `/ORCIDiD_icon64x64.png` gets Meteor's 404 "Unknown path". Only externally hosted images and the Semantic UI stylesheet, which already prepends the runtime prefix, still render.

## Fix

- New `client/lib/asset_url.js`: prepends `__meteor_runtime_config__.ROOT_URL_PATH_PREFIX` (empty string when the app is served from the host root, e.g. local `meteor` on :3000).
- The 61 static `src` values across 9 components go through `assetUrl(...)`.

Under the prefix the browser now asks for `/MagIC/MagIC/people/x.jpg`, Meteor strips one `/MagIC`, and the file is found. Without a prefix nothing changes.

## Verification

All edited files parse with Meteor's bundled Babel JSX parser. Targets `dev` so it rolls out to magic-dev before main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)